### PR TITLE
Item silent error fix

### DIFF
--- a/lib/ge/ge.helper.js
+++ b/lib/ge/ge.helper.js
@@ -17,6 +17,7 @@ let findItemByName = (itemName) => {
                         resolve(items[i].id);
                     }
                 }
+                reject(new Error("Item name not found"));
             }
             else {
                 reject(new Error("Item name not found"));

--- a/lib/ge/ge.js
+++ b/lib/ge/ge.js
@@ -18,7 +18,7 @@ function grandExchange(options) {
             } else if (typeof (item) == "string") {
                 helper.findItemByName(item).then(itemId => {
                     request.get(config.information + itemId).then(resolve).catch(reject);
-                });
+                }).catch(reject);
             } else {
                 reject(new Error("Item must be a string or integer"));
             }


### PR DESCRIPTION
When requesting an item via name that does not exist, it fails silently.

This fix rejects if name is not found, then bubbles it up to the wrapper.