### PR TITLE
feat: add collections logged minigame

### DIFF
--- a/src/hiscores/hiscores.constants.ts
+++ b/src/hiscores/hiscores.constants.ts
@@ -44,6 +44,7 @@ export const MINIGAME_NAMES = {
     'Soul Wars Zeal': 'soulWarsZeal',
     'Rifts closed': 'riftsClosed',
     'Colosseum Glory': 'colosseumGlory',
+    'Collections Logged': 'collectionsLogged'
 };
 
 export const BOSS_NAMES = {

--- a/src/hiscores/player.model.ts
+++ b/src/hiscores/player.model.ts
@@ -59,6 +59,7 @@ export interface Minigames {
     pvpArena: Minigame;
     soulWarsZeal: Minigame;
     riftsClosed: Minigame;
+    collectionsLogged: Minigame;
 }
 
 export interface Minigame {


### PR DESCRIPTION
This PR adds support for the Collections Logged feature of the Hiscores, which was added on January 29, 2025 as part of the **[Bounty Hunter Changes, Collection Log Updates & Emote Improvements](https://secure.runescape.com/m=news/bounty-hunter-changes-collection-log-updates--emote-improvements?oldschool=1)** update.